### PR TITLE
Add custom error `MicroCMS::APIError`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+Style/OpenStructUse:
+  Exclude:
+    - 'spec/**/*'

--- a/examples/examples.rb
+++ b/examples/examples.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-MicroCMS.service_domain = ENV['YOUR_DOMAIN']
-MicroCMS.api_key = ENV['YOUR_API_KEY']
+MicroCMS.service_domain = ENV.fetch('YOUR_DOMAIN', nil)
+MicroCMS.api_key = ENV.fetch('YOUR_API_KEY', nil)
 
-endpoint = ENV['YOUR_ENDPOINT']
+endpoint = ENV.fetch('YOUR_ENDPOINT', nil)
 
 puts MicroCMS.list(endpoint)
 

--- a/microcms.gemspec
+++ b/microcms.gemspec
@@ -12,9 +12,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/microcmsio/microcms-ruby-sdk'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/microcmsio/microcms-ruby-sdk'
-  spec.metadata['changelog_uri'] = 'https://github.com/microcmsio/microcms-ruby-sdk'
+  spec.metadata['homepage_uri']    = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri']   = spec.homepage
+
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/microcms_spec.rb
+++ b/spec/microcms_spec.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :request do |method, path, headers, body|
     hash = {
       method: [method, actual.method],
       path: [path, actual.path],
-      headers: [headers, headers.map { |k, _v| [k, actual[k]] }.to_h],
+      headers: [headers, headers.to_h { |k, _v| [k, actual[k]] }],
       body: [body, actual.body]
     }
     hash.all? { |_k, v| v[0] == v[1] }


### PR DESCRIPTION
Implemented `MicroCMS::APIError` to make error handling easier for users.

```ruby
client = MicroCMS::Client.new('service-domain', 'api-key')

begin
  client.update('not-existing-id', { foo: 'bar' })
rescue MicroCMS::APIError => e
  p e
end
# => #<MicroCMS::APIError @status_code=400, @body={"message"=>"Content is not exists."} @message="Content is not exists.">
```