### PR TITLE
Add a note for the MicroCMS.service_domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ MicroCMS.service_domain = 'YOUR_DOMAIN'
 MicroCMS.api_key = 'YOUR_API_KEY'
 ```
 
+Note that the `YOUR_DOMAIN` is the subdomain name of your service (not the FQDN).
+
 ### Get content list
 
 ```rb


### PR DESCRIPTION
Hi. Thanks for providing the great service and the SDK :rocket: 

I added a short notice about `MicroCMS.service_domain` in the README. Hope it helps other users.

Let me explain why. When I was trying to connect to the API with this SDK, I was getting a weird SSL handshake error that suggests that the hostname is wrong (OpenSSL::SSL::SSLError).

After a brief investigation, it turned out the problem was my `MicroCMS.service_domain`. Because I was setting the FQDN of the API like `my-service.microcms.io` the SDK was trying to connect to  `my-service.microcms.io.microcms.io`. When I changed the value to the subdomain (in this case just `my-service`), it worked.

I think maybe other users could face the same problem and it's great if we prevent this kind of confusion in advance.