### PR TITLE
chore: Fix typo in default error message: "occured" → "occurred"

### DIFF
--- a/lib/microcms.rb
+++ b/lib/microcms.rb
@@ -161,7 +161,7 @@ module MicroCMS
       @status_code = status_code
       @body = parse_body(body)
 
-      message = @body['message'] || 'Unknown error occured.'
+      message = @body['message'] || 'Unknown error occurred.'
       super(message)
     end
 


### PR DESCRIPTION
- Summary: Correct a spelling mistake in the default error message used by `MicroCMS::APIError` when no message is provided by the API.
- Change: Replace "Unknown error occured." with "Unknown error occurred." in `lib/microcms.rb`.
- Impact: No behavior or API changes; user-facing message only.